### PR TITLE
Pin action dependencies to specific versions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -74,13 +74,13 @@ runs:
   using: "composite"
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # https://github.com/actions/setup-node/releases/tag/v4.4.0
       with:
         node-version: "18.x"
         cache: ${{ inputs.use_node_cache == 'true' && 'npm' || '' }}
 
     - name: Install Bun
-      uses: oven-sh/setup-bun@v2
+      uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # https://github.com/oven-sh/setup-bun/releases/tag/v2.0.2
       with:
         bun-version: 1.2.11
 
@@ -92,7 +92,7 @@ runs:
 
     - name: Install Claude Code
       shell: bash
-      run: npm install -g @anthropic-ai/claude-code@^1.0.2
+      run: npm install -g @anthropic-ai/claude-code@1.0.2
 
     - name: Run Claude Code Action
       shell: bash


### PR DESCRIPTION
- Pin setup-node to commit SHA v4.4.0
- Pin setup-bun to commit SHA v2.0.2
- Pin claude-code to exact version 1.0.2 (remove ^)

Relates to https://github.com/anthropics/claude-code-action/issues/15. Will follow up with a commit in that repo as well once this is in.

🤖 Generated with [Claude Code](https://claude.ai/code)