### PR TITLE
Support ANTHROPIC_BASE_URL override from env

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -113,6 +113,7 @@ runs:
 
         # Provider configuration
         ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
+        ANTHROPIC_BASE_URL: ${{ env.ANTHROPIC_BASE_URL }}
         # Only set provider flags if explicitly true, since any value (including "false") is truthy
         CLAUDE_CODE_USE_BEDROCK: ${{ inputs.use_bedrock == 'true' && '1' || '' }}
         CLAUDE_CODE_USE_VERTEX: ${{ inputs.use_vertex == 'true' && '1' || '' }}


### PR DESCRIPTION
We would like to override the ANTHROPIC_BASE_URL when using the claude-code github action.
Related PR.