### PR TITLE
Make Node.js version configurable via NODE_VERSION environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,26 @@ Add the following to your workflow file:
 | `conclusion`     | Execution status of Claude Code ('success' or 'failure')   |
 | `execution_file` | Path to the JSON file containing Claude Code execution log |
 
+## Environment Variables
+
+The following environment variables can be used to configure the action:
+
+| Variable       | Description                                           | Default |
+| -------------- | ----------------------------------------------------- | ------- |
+| `NODE_VERSION` | Node.js version to use (e.g., '18.x', '20.x', '22.x') | '18.x'  |
+
+Example usage:
+
+```yaml
+- name: Run Claude Code with Node.js 20
+  uses: anthropics/claude-code-base-action@beta
+  env:
+    NODE_VERSION: "20.x"
+  with:
+    prompt: "Your prompt here"
+    anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+```
+
 ## Using MCP Config
 
 You can provide a custom MCP configuration file to dynamically load MCP servers:

--- a/action.yml
+++ b/action.yml
@@ -76,7 +76,7 @@ runs:
     - name: Setup Node.js
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # https://github.com/actions/setup-node/releases/tag/v4.4.0
       with:
-        node-version: "18.x"
+        node-version: ${{ env.NODE_VERSION || '18.x' }}
         cache: ${{ inputs.use_node_cache == 'true' && 'npm' || '' }}
 
     - name: Install Bun


### PR DESCRIPTION
## Summary
- Make Node.js version configurable through NODE_VERSION environment variable
- Default to Node.js 18.x if not specified

## Changes
- Updated `action.yml` to use `${{ env.NODE_VERSION || '18.x' }}` instead of hardcoded version
- Added Environment Variables section to README.md with documentation and usage example

This allows users to specify their preferred Node.js version without modifying the action:

```yaml
- uses: anthropics/claude-code-base-action@beta
  env:
    NODE_VERSION: '20.x'
  with:
    prompt: "Your prompt here"
    anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
```

Related to https://github.com/anthropics/claude-code-action/issues/56

🤖 Generated with [Claude Code](https://claude.ai/code)