### PR TITLE
Add workflow to automatically update downstream action on release

### DIFF
--- a/.github/workflows/update-downstream-action.yml
+++ b/.github/workflows/update-downstream-action.yml
@@ -1,0 +1,105 @@
+name: Update Downstream Action
+
+# This workflow updates the anthropics/claude-code-action repository
+# when a new release tag is created in this repository
+
+on:
+  push:
+    tags:
+      - "v*.*.*" # Trigger on version tags like v1.2.3
+
+permissions:
+  contents: read
+
+jobs:
+  update-downstream:
+    name: Update claude-code-action SHA
+    runs-on: ubuntu-latest
+    environment: release
+    timeout-minutes: 10
+    steps:
+      - name: Checkout current repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get release information
+        id: release_info
+        run: |
+          # Get the tag name and SHA
+          TAG_NAME=${GITHUB_REF#refs/tags/}
+          TAG_SHA=$(git rev-parse HEAD)
+          echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
+          echo "TAG_SHA=$TAG_SHA" >> $GITHUB_ENV
+          echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
+          echo "tag_sha=$TAG_SHA" >> $GITHUB_OUTPUT
+
+      - name: Create branch and update action.yml
+        run: |
+          # Variables
+          TIMESTAMP=$(date +'%Y%m%d-%H%M%S')
+          BRANCH_NAME="update-claude-code-base-action-${{ env.TAG_NAME }}-$TIMESTAMP"
+          TARGET_REPO="anthropics/claude-code-action"
+
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+          echo "TARGET_REPO=$TARGET_REPO" >> $GITHUB_ENV
+
+          # Get the default branch of the target repo
+          DEFAULT_BRANCH=$(gh api repos/$TARGET_REPO --jq '.default_branch')
+          echo "DEFAULT_BRANCH=$DEFAULT_BRANCH" >> $GITHUB_ENV
+
+          # Get the latest commit SHA from the default branch
+          BASE_SHA=$(gh api repos/$TARGET_REPO/git/refs/heads/$DEFAULT_BRANCH --jq '.object.sha')
+
+          # Create a new branch in the target repo
+          gh api \
+            --method POST \
+            repos/$TARGET_REPO/git/refs \
+            -f ref="refs/heads/$BRANCH_NAME" \
+            -f sha="$BASE_SHA"
+
+          # Get the current action.yml content
+          ACTION_CONTENT=$(gh api repos/$TARGET_REPO/contents/action.yml?ref=$DEFAULT_BRANCH --jq '.content' | base64 -d)
+
+          # Update the SHA and comment in the action.yml
+          # This assumes the action.yml has a line like:
+          # uses: anthropics/claude-code-base-action@SHA # comment
+          UPDATED_CONTENT=$(echo "$ACTION_CONTENT" | sed -E "s|(uses: anthropics/claude-code-base-action@)[a-f0-9]{40}( *# *.*)?|\1${{ env.TAG_SHA }} # ${{ env.TAG_NAME }}|g")
+
+          # Get the current SHA of action.yml for the update API call
+          FILE_SHA=$(gh api repos/$TARGET_REPO/contents/action.yml?ref=$DEFAULT_BRANCH --jq '.sha')
+
+          # Create the updated action.yml content in base64
+          echo "$UPDATED_CONTENT" | base64 > action.yml.b64
+
+          # Commit the updated action.yml via GitHub API
+          gh api \
+            --method PUT \
+            repos/$TARGET_REPO/contents/action.yml \
+            -f message="chore: update claude-code-base-action to ${{ env.TAG_NAME }}" \
+            -F content=@action.yml.b64 \
+            -f sha="$FILE_SHA" \
+            -f branch="$BRANCH_NAME"
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+
+      - name: Create Pull Request
+        run: |
+          # Create PR body with proper YAML escape
+          printf -v PR_BODY "## Update claude-code-base-action to ${{ env.TAG_NAME }}\n\nThis PR updates the claude-code-base-action reference to the latest release.\n\n### Changes\n- Updated SHA: \`${{ env.TAG_SHA }}\`\n- Updated version: \`${{ env.TAG_NAME }}\`\n\n### Release Information\n- Repository: anthropics/claude-code-base-action\n- Release: [${{ env.TAG_NAME }}](https://github.com/anthropics/claude-code-base-action/releases/tag/${{ env.TAG_NAME }})\n- Commit: [\`${TAG_SHA:0:7}\`](https://github.com/anthropics/claude-code-base-action/commit/${{ env.TAG_SHA }})\n\n🤖 This PR was automatically created by the release workflow."
+          echo "PR body created"
+
+          echo "Creating PR with gh pr create command"
+          echo "Branch name: ${{ env.BRANCH_NAME }}"
+          PR_URL=$(gh pr create \
+            --repo "${{ env.TARGET_REPO }}" \
+            --title "chore: update claude-code-base-action to ${{ env.TAG_NAME }}" \
+            --body "$PR_BODY" \
+            --base "${{ env.DEFAULT_BRANCH }}" \
+            --head "${{ env.BRANCH_NAME }}")
+          echo "PR created successfully"
+          echo "PR URL: $PR_URL"
+
+          echo "PR_URL=$PR_URL" >> $GITHUB_ENV
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}


### PR DESCRIPTION
This workflow triggers when a version tag is created and automatically opens a PR in claude-code-action to update the SHA reference.

🤖 Generated with [Claude Code](https://claude.ai/code)