### PR TITLE
fix: use RELEASE_PAT for all GitHub API operations in downstream update workflow

### DIFF
--- a/.github/workflows/update-downstream-action.yml
+++ b/.github/workflows/update-downstream-action.yml
@@ -2,11 +2,6 @@ name: Update Downstream Action
 
 # This workflow updates the anthropics/claude-code-action repository
 # when a new release tag is created in this repository
-#
-# IMPORTANT: This workflow uses RELEASE_PAT instead of GITHUB_TOKEN for PR creation because:
-# 1. GITHUB_TOKEN doesn't trigger workflows recursively, preventing CI from running on the PR
-# 2. RELEASE_PAT has higher permissions needed for cross-repo access
-# We use GITHUB_TOKEN for commits via the gh api to get commit signing
 
 on:
   push:
@@ -87,7 +82,7 @@ jobs:
             -f sha="$FILE_SHA" \
             -f branch="$BRANCH_NAME"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
 
       - name: Create Pull Request
         run: |


### PR DESCRIPTION
- Switch from GITHUB_TOKEN to RELEASE_PAT for branch/commit creation
- Remove misleading comment about token usage
- Fixes "Resource not accessible by integration" error when creating branches in external repo

🤖 Generated with [Claude Code](https://claude.ai/code)