### PR TITLE
feat: add support for --system-prompt and --append-system-prompt args

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,25 +33,45 @@ Add the following to your workflow file:
     allowed_tools: "Bash(git:*),View,GlobTool,GrepTool,BatchTool"
     max_turns: "5" # Limit conversation to 5 turns
     anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+# Using custom system prompts (only works with print mode)
+- name: Run Claude Code with custom system prompt
+  uses: anthropics/claude-code-base-action@beta
+  with:
+    prompt: "Build a REST API"
+    system_prompt: "You are a senior backend engineer. Focus on security, performance, and maintainability."
+    allowed_tools: "Bash(git:*),View,GlobTool,GrepTool,BatchTool"
+    anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+# Or appending to the default system prompt
+- name: Run Claude Code with appended system prompt
+  uses: anthropics/claude-code-base-action@beta
+  with:
+    prompt: "Create a database schema"
+    append_system_prompt: "After writing code, be sure to code review yourself."
+    allowed_tools: "Bash(git:*),View,GlobTool,GrepTool,BatchTool"
+    anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 ```
 
 ## Inputs
 
-| Input               | Description                                                                                       | Required | Default                      |
-| ------------------- | ------------------------------------------------------------------------------------------------- | -------- | ---------------------------- |
-| `prompt`            | The prompt to send to Claude Code                                                                 | No\*     | ''                           |
-| `prompt_file`       | Path to a file containing the prompt to send to Claude Code                                       | No\*     | ''                           |
-| `allowed_tools`     | Comma-separated list of allowed tools for Claude Code to use                                      | No       | ''                           |
-| `disallowed_tools`  | Comma-separated list of disallowed tools that Claude Code cannot use                              | No       | ''                           |
-| `max_turns`         | Maximum number of conversation turns (default: no limit)                                          | No       | ''                           |
-| `mcp_config`        | Path to the MCP configuration JSON file                                                           | No       | ''                           |
-| `model`             | Model to use (provider-specific format required for Bedrock/Vertex)                               | No       | 'claude-3-7-sonnet-20250219' |
-| `anthropic_model`   | DEPRECATED: Use 'model' instead                                                                   | No       | 'claude-3-7-sonnet-20250219' |
-| `timeout_minutes`   | Timeout in minutes for Claude Code execution                                                      | No       | '10'                         |
-| `anthropic_api_key` | Anthropic API key (required for direct Anthropic API)                                             | No       | ''                           |
-| `use_bedrock`       | Use Amazon Bedrock with OIDC authentication instead of direct Anthropic API                       | No       | 'false'                      |
-| `use_vertex`        | Use Google Vertex AI with OIDC authentication instead of direct Anthropic API                     | No       | 'false'                      |
-| `use_node_cache`    | Whether to use Node.js dependency caching (set to true only for Node.js projects with lock files) | No       | 'false'                      |
+| Input                  | Description                                                                                       | Required | Default                      |
+| ---------------------- | ------------------------------------------------------------------------------------------------- | -------- | ---------------------------- |
+| `prompt`               | The prompt to send to Claude Code                                                                 | No\*     | ''                           |
+| `prompt_file`          | Path to a file containing the prompt to send to Claude Code                                       | No\*     | ''                           |
+| `allowed_tools`        | Comma-separated list of allowed tools for Claude Code to use                                      | No       | ''                           |
+| `disallowed_tools`     | Comma-separated list of disallowed tools that Claude Code cannot use                              | No       | ''                           |
+| `max_turns`            | Maximum number of conversation turns (default: no limit)                                          | No       | ''                           |
+| `mcp_config`           | Path to the MCP configuration JSON file                                                           | No       | ''                           |
+| `system_prompt`        | Override system prompt (only works with print mode)                                               | No       | ''                           |
+| `append_system_prompt` | Append to system prompt (only works with print mode)                                              | No       | ''                           |
+| `model`                | Model to use (provider-specific format required for Bedrock/Vertex)                               | No       | 'claude-3-7-sonnet-20250219' |
+| `anthropic_model`      | DEPRECATED: Use 'model' instead                                                                   | No       | 'claude-3-7-sonnet-20250219' |
+| `timeout_minutes`      | Timeout in minutes for Claude Code execution                                                      | No       | '10'                         |
+| `anthropic_api_key`    | Anthropic API key (required for direct Anthropic API)                                             | No       | ''                           |
+| `use_bedrock`          | Use Amazon Bedrock with OIDC authentication instead of direct Anthropic API                       | No       | 'false'                      |
+| `use_vertex`           | Use Google Vertex AI with OIDC authentication instead of direct Anthropic API                     | No       | 'false'                      |
+| `use_node_cache`       | Whether to use Node.js dependency caching (set to true only for Node.js projects with lock files) | No       | 'false'                      |
 
 \*Either `prompt` or `prompt_file` must be provided, but not both.
 

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ Add the following to your workflow file:
 | `disallowed_tools`     | Comma-separated list of disallowed tools that Claude Code cannot use                              | No       | ''                           |
 | `max_turns`            | Maximum number of conversation turns (default: no limit)                                          | No       | ''                           |
 | `mcp_config`           | Path to the MCP configuration JSON file                                                           | No       | ''                           |
-| `system_prompt`        | Override system prompt                                                                             | No       | ''                           |
-| `append_system_prompt` | Append to system prompt                                                                            | No       | ''                           |
+| `system_prompt`        | Override system prompt                                                                            | No       | ''                           |
+| `append_system_prompt` | Append to system prompt                                                                           | No       | ''                           |
 | `model`                | Model to use (provider-specific format required for Bedrock/Vertex)                               | No       | 'claude-3-7-sonnet-20250219' |
 | `anthropic_model`      | DEPRECATED: Use 'model' instead                                                                   | No       | 'claude-3-7-sonnet-20250219' |
 | `timeout_minutes`      | Timeout in minutes for Claude Code execution                                                      | No       | '10'                         |

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Add the following to your workflow file:
     max_turns: "5" # Limit conversation to 5 turns
     anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
-# Using custom system prompts (only works with print mode)
+# Using custom system prompts
 - name: Run Claude Code with custom system prompt
   uses: anthropics/claude-code-base-action@beta
   with:
@@ -63,8 +63,8 @@ Add the following to your workflow file:
 | `disallowed_tools`     | Comma-separated list of disallowed tools that Claude Code cannot use                              | No       | ''                           |
 | `max_turns`            | Maximum number of conversation turns (default: no limit)                                          | No       | ''                           |
 | `mcp_config`           | Path to the MCP configuration JSON file                                                           | No       | ''                           |
-| `system_prompt`        | Override system prompt (only works with print mode)                                               | No       | ''                           |
-| `append_system_prompt` | Append to system prompt (only works with print mode)                                              | No       | ''                           |
+| `system_prompt`        | Override system prompt                                                                             | No       | ''                           |
+| `append_system_prompt` | Append to system prompt                                                                            | No       | ''                           |
 | `model`                | Model to use (provider-specific format required for Bedrock/Vertex)                               | No       | 'claude-3-7-sonnet-20250219' |
 | `anthropic_model`      | DEPRECATED: Use 'model' instead                                                                   | No       | 'claude-3-7-sonnet-20250219' |
 | `timeout_minutes`      | Timeout in minutes for Claude Code execution                                                      | No       | '10'                         |

--- a/action.yml
+++ b/action.yml
@@ -31,11 +31,11 @@ inputs:
     required: false
     default: ""
   system_prompt:
-    description: "Override system prompt (only works with print mode)"
+    description: "Override system prompt"
     required: false
     default: ""
   append_system_prompt:
-    description: "Append to system prompt (only works with print mode)"
+    description: "Append to system prompt"
     required: false
     default: ""
   model:

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,14 @@ inputs:
     description: "MCP configuration as JSON string or path to MCP configuration JSON file"
     required: false
     default: ""
+  system_prompt:
+    description: "Override system prompt (only works with print mode)"
+    required: false
+    default: ""
+  append_system_prompt:
+    description: "Append to system prompt (only works with print mode)"
+    required: false
+    default: ""
   model:
     description: "Model to use (provider-specific format required for Bedrock/Vertex)"
     required: false
@@ -114,6 +122,8 @@ runs:
         INPUT_DISALLOWED_TOOLS: ${{ inputs.disallowed_tools }}
         INPUT_MAX_TURNS: ${{ inputs.max_turns }}
         INPUT_MCP_CONFIG: ${{ inputs.mcp_config }}
+        INPUT_SYSTEM_PROMPT: ${{ inputs.system_prompt }}
+        INPUT_APPEND_SYSTEM_PROMPT: ${{ inputs.append_system_prompt }}
         INPUT_TIMEOUT_MINUTES: ${{ inputs.timeout_minutes }}
 
         # Provider configuration

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,8 @@ async function run() {
       disallowedTools: process.env.INPUT_DISALLOWED_TOOLS,
       maxTurns: process.env.INPUT_MAX_TURNS,
       mcpConfig: process.env.INPUT_MCP_CONFIG,
+      systemPrompt: process.env.INPUT_SYSTEM_PROMPT,
+      appendSystemPrompt: process.env.INPUT_APPEND_SYSTEM_PROMPT,
     });
   } catch (error) {
     core.setFailed(`Action failed with error: ${error}`);

--- a/src/run-claude.ts
+++ b/src/run-claude.ts
@@ -16,6 +16,8 @@ export type ClaudeOptions = {
   disallowedTools?: string;
   maxTurns?: string;
   mcpConfig?: string;
+  systemPrompt?: string;
+  appendSystemPrompt?: string;
 };
 
 type PreparedConfig = {
@@ -46,6 +48,12 @@ export function prepareRunConfig(
   }
   if (options.mcpConfig) {
     claudeArgs.push("--mcp-config", options.mcpConfig);
+  }
+  if (options.systemPrompt) {
+    claudeArgs.push("--system-prompt", options.systemPrompt);
+  }
+  if (options.appendSystemPrompt) {
+    claudeArgs.push("--append-system-prompt", options.appendSystemPrompt);
   }
 
   return {

--- a/test/run-claude.test.ts
+++ b/test/run-claude.test.ts
@@ -75,12 +75,15 @@ describe("prepareRunConfig", () => {
 
   test("should include append system prompt in command arguments", () => {
     const options: ClaudeOptions = {
-      appendSystemPrompt: "After writing code, be sure to code review yourself.",
+      appendSystemPrompt:
+        "After writing code, be sure to code review yourself.",
     };
     const prepared = prepareRunConfig("/tmp/test-prompt.txt", options);
 
     expect(prepared.claudeArgs).toContain("--append-system-prompt");
-    expect(prepared.claudeArgs).toContain("After writing code, be sure to code review yourself.");
+    expect(prepared.claudeArgs).toContain(
+      "After writing code, be sure to code review yourself.",
+    );
   });
 
   test("should use provided prompt path", () => {

--- a/test/run-claude.test.ts
+++ b/test/run-claude.test.ts
@@ -63,6 +63,26 @@ describe("prepareRunConfig", () => {
     expect(prepared.claudeArgs).toContain("/path/to/mcp-config.json");
   });
 
+  test("should include system prompt in command arguments", () => {
+    const options: ClaudeOptions = {
+      systemPrompt: "You are a senior backend engineer.",
+    };
+    const prepared = prepareRunConfig("/tmp/test-prompt.txt", options);
+
+    expect(prepared.claudeArgs).toContain("--system-prompt");
+    expect(prepared.claudeArgs).toContain("You are a senior backend engineer.");
+  });
+
+  test("should include append system prompt in command arguments", () => {
+    const options: ClaudeOptions = {
+      appendSystemPrompt: "After writing code, be sure to code review yourself.",
+    };
+    const prepared = prepareRunConfig("/tmp/test-prompt.txt", options);
+
+    expect(prepared.claudeArgs).toContain("--append-system-prompt");
+    expect(prepared.claudeArgs).toContain("After writing code, be sure to code review yourself.");
+  });
+
   test("should use provided prompt path", () => {
     const options: ClaudeOptions = {};
     const prepared = prepareRunConfig("/custom/prompt/path.txt", options);
@@ -78,6 +98,8 @@ describe("prepareRunConfig", () => {
     expect(prepared.claudeArgs).not.toContain("--disallowedTools");
     expect(prepared.claudeArgs).not.toContain("--max-turns");
     expect(prepared.claudeArgs).not.toContain("--mcp-config");
+    expect(prepared.claudeArgs).not.toContain("--system-prompt");
+    expect(prepared.claudeArgs).not.toContain("--append-system-prompt");
   });
 
   test("should preserve order of claude arguments", () => {


### PR DESCRIPTION
Add support for system prompt customization in Claude Code GitHub Action

## Changes
- Add `system_prompt` and `append_system_prompt` inputs to action.yml
- Update environment variables to pass new inputs to Claude Code
- Extend ClaudeOptions type and prepareRunConfig function to handle system prompt flags
- Add usage examples and documentation to README
- Add comprehensive test coverage for new functionality

Both options only work with print mode (non-interactive) as per Claude Code SDK.

Closes #30

Generated with [Claude Code](https://claude.ai/code)