### PR TITLE
feat: add repository dispatch workflow to bump Claude Code version

### DIFF
--- a/.github/workflows/bump-claude-code-version.yml
+++ b/.github/workflows/bump-claude-code-version.yml
@@ -1,0 +1,65 @@
+name: Bump Claude Code Version
+
+on:
+  repository_dispatch:
+    types: [bump_claude_code_version]
+
+permissions:
+  contents: write
+
+jobs:
+  bump-version:
+    name: Bump Claude Code Version
+    runs-on: ubuntu-latest
+    environment: release
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.RELEASE_PAT }}
+          fetch-depth: 0
+
+      - name: Get version from event payload
+        id: get_version
+        run: |
+          NEW_VERSION="${{ github.event.client_payload.version }}"
+          if [ -z "$NEW_VERSION" ]; then
+            echo "Error: version not provided in client_payload"
+            exit 1
+          fi
+          echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Update Claude Code version via GitHub API
+        run: |
+          # Get the current action.yml content
+          ACTION_CONTENT=$(gh api repos/${{ github.repository }}/contents/action.yml --jq '.content' | base64 -d)
+          
+          # Update the Claude Code version in the npm install command
+          UPDATED_CONTENT=$(echo "$ACTION_CONTENT" | sed -E "s/(npm install -g @anthropic-ai\/claude-code@)[0-9]+\.[0-9]+\.[0-9]+/\1${{ env.NEW_VERSION }}/")
+          
+          # Verify the change would be made
+          if ! echo "$UPDATED_CONTENT" | grep -q "@anthropic-ai/claude-code@${{ env.NEW_VERSION }}"; then
+            echo "Error: Failed to update Claude Code version in content"
+            exit 1
+          fi
+          
+          # Get the current SHA of action.yml for the update API call
+          FILE_SHA=$(gh api repos/${{ github.repository }}/contents/action.yml --jq '.sha')
+          
+          # Create the updated action.yml content in base64
+          echo "$UPDATED_CONTENT" | base64 > action.yml.b64
+          
+          # Commit the updated action.yml via GitHub API
+          gh api \
+            --method PUT \
+            repos/${{ github.repository }}/contents/action.yml \
+            -f message="chore: bump Claude Code version to ${{ env.NEW_VERSION }}" \
+            -F content=@action.yml.b64 \
+            -f sha="$FILE_SHA" \
+            -f branch="${{ github.ref_name }}"
+          
+          echo "Successfully updated Claude Code version to ${{ env.NEW_VERSION }} via GitHub API"
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}

--- a/.github/workflows/bump-claude-code-version.yml
+++ b/.github/workflows/bump-claude-code-version.yml
@@ -3,6 +3,12 @@ name: Bump Claude Code Version
 on:
   repository_dispatch:
     types: [bump_claude_code_version]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Claude Code version to bump to"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -23,34 +29,60 @@ jobs:
       - name: Get version from event payload
         id: get_version
         run: |
-          NEW_VERSION="${{ github.event.client_payload.version }}"
+          # Get version from either repository_dispatch or workflow_dispatch
+          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
+            NEW_VERSION="${{ github.event.client_payload.version }}"
+          else
+            NEW_VERSION="${{ inputs.version }}"
+          fi
+
           if [ -z "$NEW_VERSION" ]; then
-            echo "Error: version not provided in client_payload"
+            echo "Error: version not provided"
             exit 1
           fi
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
           echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
 
-      - name: Update Claude Code version via GitHub API
+      - name: Create branch and update action.yml
         run: |
+          # Variables
+          TIMESTAMP=$(date +'%Y%m%d-%H%M%S')
+          BRANCH_NAME="bump-claude-code-${{ env.NEW_VERSION }}-$TIMESTAMP"
+
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+
+          # Get the default branch
+          DEFAULT_BRANCH=$(gh api repos/${{ github.repository }} --jq '.default_branch')
+          echo "DEFAULT_BRANCH=$DEFAULT_BRANCH" >> $GITHUB_ENV
+
+          # Get the latest commit SHA from the default branch
+          BASE_SHA=$(gh api repos/${{ github.repository }}/git/refs/heads/$DEFAULT_BRANCH --jq '.object.sha')
+
+          # Create a new branch
+          gh api \
+            --method POST \
+            repos/${{ github.repository }}/git/refs \
+            -f ref="refs/heads/$BRANCH_NAME" \
+            -f sha="$BASE_SHA"
+
           # Get the current action.yml content
-          ACTION_CONTENT=$(gh api repos/${{ github.repository }}/contents/action.yml --jq '.content' | base64 -d)
-          
+          ACTION_CONTENT=$(gh api repos/${{ github.repository }}/contents/action.yml?ref=$DEFAULT_BRANCH --jq '.content' | base64 -d)
+
           # Update the Claude Code version in the npm install command
           UPDATED_CONTENT=$(echo "$ACTION_CONTENT" | sed -E "s/(npm install -g @anthropic-ai\/claude-code@)[0-9]+\.[0-9]+\.[0-9]+/\1${{ env.NEW_VERSION }}/")
-          
+
           # Verify the change would be made
           if ! echo "$UPDATED_CONTENT" | grep -q "@anthropic-ai/claude-code@${{ env.NEW_VERSION }}"; then
             echo "Error: Failed to update Claude Code version in content"
             exit 1
           fi
-          
+
           # Get the current SHA of action.yml for the update API call
-          FILE_SHA=$(gh api repos/${{ github.repository }}/contents/action.yml --jq '.sha')
-          
+          FILE_SHA=$(gh api repos/${{ github.repository }}/contents/action.yml?ref=$DEFAULT_BRANCH --jq '.sha')
+
           # Create the updated action.yml content in base64
           echo "$UPDATED_CONTENT" | base64 > action.yml.b64
-          
+
           # Commit the updated action.yml via GitHub API
           gh api \
             --method PUT \
@@ -58,8 +90,32 @@ jobs:
             -f message="chore: bump Claude Code version to ${{ env.NEW_VERSION }}" \
             -F content=@action.yml.b64 \
             -f sha="$FILE_SHA" \
-            -f branch="${{ github.ref_name }}"
-          
-          echo "Successfully updated Claude Code version to ${{ env.NEW_VERSION }} via GitHub API"
+            -f branch="$BRANCH_NAME"
+
+          echo "Successfully created branch and updated Claude Code version to ${{ env.NEW_VERSION }}"
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+
+      - name: Create Pull Request
+        run: |
+          # Determine trigger type for PR body
+          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
+            TRIGGER_INFO="repository dispatch event"
+          else
+            TRIGGER_INFO="manual workflow dispatch by @${{ github.actor }}"
+          fi
+
+          # Create PR body with proper YAML escape
+          printf -v PR_BODY "## Bump Claude Code to ${{ env.NEW_VERSION }}\n\nThis PR updates the Claude Code version in action.yml to ${{ env.NEW_VERSION }}.\n\n### Changes\n- Updated Claude Code version from current to \`${{ env.NEW_VERSION }}\`\n\n### Triggered by\n- $TRIGGER_INFO\n\n🤖 This PR was automatically created by the bump-claude-code-version workflow."
+
+          echo "Creating PR with gh pr create command"
+          PR_URL=$(gh pr create \
+            --repo "${{ github.repository }}" \
+            --title "chore: bump Claude Code version to ${{ env.NEW_VERSION }}" \
+            --body "$PR_BODY" \
+            --base "${{ env.DEFAULT_BRANCH }}" \
+            --head "${{ env.BRANCH_NAME }}")
+
+          echo "PR created successfully: $PR_URL"
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PAT }}


### PR DESCRIPTION
## Summary
- Added new repository dispatch workflow that automatically bumps the Claude Code version in action.yml
- Workflow is triggered via GitHub API with event type `bump_claude_code_version`
- Uses GitHub API to commit changes directly without local git operations

## Implementation Details
- Workflow expects new version in `client_payload.version`
- Uses the `release` environment to access `RELEASE_PAT` secret
- Updates the npm install line in action.yml using sed pattern matching
- Commits changes via GitHub Contents API

## Usage Example
```bash
gh api \
  --method POST \
  repos/anthropics/claude-code-base-action/dispatches \
  -f event_type=bump_claude_code_version \
  -f 'client_payload[version]=1.0.10'
```

## Test plan
- [ ] Trigger the workflow with a test version number
- [ ] Verify the action.yml file is updated correctly
- [ ] Confirm the commit is created with proper message format

🤖 Generated with [Claude Code](https://claude.ai/code)