### PR TITLE
fix: use GITHUB_ACTION_PATH environment variable instead of github.action_path expression

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -99,7 +99,7 @@ runs:
     - name: Install Dependencies
       shell: bash
       run: |
-        cd ${{ github.action_path }}
+        cd ${GITHUB_ACTION_PATH}
         bun install
 
     - name: Install Claude Code
@@ -115,7 +115,7 @@ runs:
           echo "Changing directory to CLAUDE_WORKING_DIR: $CLAUDE_WORKING_DIR"
           cd "$CLAUDE_WORKING_DIR"
         fi
-        bun run ${{ github.action_path }}/src/index.ts
+        bun run ${GITHUB_ACTION_PATH}/src/index.ts
       env:
         # Model configuration
         CLAUDE_CODE_ACTION: "1"


### PR DESCRIPTION
This fixes compatibility with containerized workflow jobs where the `${{ github.action_path }}` expression doesn't work properly.

Fixes #41

Generated with [Claude Code](https://claude.ai/code)