### PR TITLE
feat: update downstream action workflow to use deploy key

### DIFF
--- a/.github/workflows/update-downstream-action.yml
+++ b/.github/workflows/update-downstream-action.yml
@@ -8,10 +8,6 @@ on:
     tags:
       - "v*.*.*" # Trigger on version tags like v1.2.3
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   update-downstream:
     name: Update claude-code-action SHA
@@ -35,72 +31,53 @@ jobs:
           echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
           echo "tag_sha=$TAG_SHA" >> $GITHUB_OUTPUT
 
-      - name: Create branch and update action.yml
+      - name: Clone claude-code-action repository
         run: |
-          # Variables
-          TIMESTAMP=$(date +'%Y%m%d-%H%M%S')
-          BRANCH_NAME="update-claude-code-base-action-${{ env.TAG_NAME }}-$TIMESTAMP"
-          TARGET_REPO="anthropics/claude-code-action"
+          # Configure git with the deploy key
+          mkdir -p ~/.ssh
+          echo "${{ secrets.CLAUDE_CODE_ACTION_REPO_DEPLOY_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
 
-          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
-          echo "TARGET_REPO=$TARGET_REPO" >> $GITHUB_ENV
+          # Configure SSH to use the deploy key
+          cat > ~/.ssh/config <<EOL
+          Host github.com
+            HostName github.com
+            User git
+            IdentityFile ~/.ssh/deploy_key
+            StrictHostKeyChecking no
+          EOL
 
-          # Get the default branch of the target repo
-          DEFAULT_BRANCH=$(gh api repos/$TARGET_REPO --jq '.default_branch')
-          echo "DEFAULT_BRANCH=$DEFAULT_BRANCH" >> $GITHUB_ENV
+          # Clone the target repository
+          git clone git@github.com:anthropics/claude-code-action.git target
 
-          # Get the latest commit SHA from the default branch
-          BASE_SHA=$(gh api repos/$TARGET_REPO/git/refs/heads/$DEFAULT_BRANCH --jq '.object.sha')
+      - name: Update and push action.yml
+        run: |
+          cd target
 
-          # Create a new branch in the target repo
-          gh api \
-            --method POST \
-            repos/$TARGET_REPO/git/refs \
-            -f ref="refs/heads/$BRANCH_NAME" \
-            -f sha="$BASE_SHA"
+          # Configure git
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
 
-          # Get the current action.yml content
-          ACTION_CONTENT=$(gh api repos/$TARGET_REPO/contents/action.yml?ref=$DEFAULT_BRANCH --jq '.content' | base64 -d)
+          # Read the current action.yml content
+          ACTION_CONTENT=$(cat action.yml)
 
           # Update the SHA and comment in the action.yml
           # This assumes the action.yml has a line like:
           # uses: anthropics/claude-code-base-action@SHA # comment
           UPDATED_CONTENT=$(echo "$ACTION_CONTENT" | sed -E "s|(uses: anthropics/claude-code-base-action@)[a-f0-9]{40}( *# *.*)?|\1${{ env.TAG_SHA }} # ${{ env.TAG_NAME }}|g")
 
-          # Get the current SHA of action.yml for the update API call
-          FILE_SHA=$(gh api repos/$TARGET_REPO/contents/action.yml?ref=$DEFAULT_BRANCH --jq '.sha')
+          # Write the updated content
+          echo "$UPDATED_CONTENT" > action.yml
 
-          # Create the updated action.yml content in base64
-          echo "$UPDATED_CONTENT" | base64 > action.yml.b64
+          # Check if there are changes
+          if git diff --quiet; then
+            echo "No changes to action.yml, skipping push"
+            exit 0
+          fi
 
-          # Commit the updated action.yml via GitHub API
-          gh api \
-            --method PUT \
-            repos/$TARGET_REPO/contents/action.yml \
-            -f message="chore: update claude-code-base-action to ${{ env.TAG_NAME }}" \
-            -F content=@action.yml.b64 \
-            -f sha="$FILE_SHA" \
-            -f branch="$BRANCH_NAME"
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          # Commit and push if there are changes
+          git add action.yml
+          git commit -m "chore: update claude-code-base-action to ${{ env.TAG_NAME }}"
+          git push origin main
 
-      - name: Create Pull Request
-        run: |
-          # Create PR body with proper YAML escape
-          printf -v PR_BODY "## Update claude-code-base-action to ${{ env.TAG_NAME }}\n\nThis PR updates the claude-code-base-action reference to the latest release.\n\n### Changes\n- Updated SHA: \`${{ env.TAG_SHA }}\`\n- Updated version: \`${{ env.TAG_NAME }}\`\n\n### Release Information\n- Repository: anthropics/claude-code-base-action\n- Release: [${{ env.TAG_NAME }}](https://github.com/anthropics/claude-code-base-action/releases/tag/${{ env.TAG_NAME }})\n- Commit: [\`${TAG_SHA:0:7}\`](https://github.com/anthropics/claude-code-base-action/commit/${{ env.TAG_SHA }})\n\n🤖 This PR was automatically created by the release workflow."
-          echo "PR body created"
-
-          echo "Creating PR with gh pr create command"
-          echo "Branch name: ${{ env.BRANCH_NAME }}"
-          PR_URL=$(gh pr create \
-            --repo "${{ env.TARGET_REPO }}" \
-            --title "chore: update claude-code-base-action to ${{ env.TAG_NAME }}" \
-            --body "$PR_BODY" \
-            --base "${{ env.DEFAULT_BRANCH }}" \
-            --head "${{ env.BRANCH_NAME }}")
-          echo "PR created successfully"
-          echo "PR URL: $PR_URL"
-
-          echo "PR_URL=$PR_URL" >> $GITHUB_ENV
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          echo "Successfully updated action.yml with claude-code-base-action ${{ env.TAG_NAME }}"


### PR DESCRIPTION
## Summary
- Updated the update-downstream-action.yml workflow to use SSH deploy key authentication instead of PAT
- Simplified workflow by pushing directly to main instead of creating branches and PRs
- Aligned with the pattern used in sync-changelog.yml for consistency

## Changes
- Removed pull-request permissions (no longer needed)
- Added SSH configuration using `CLAUDE_CODE_ACTION_REPO_DEPLOY_KEY`
- Changed from GitHub API operations to direct git clone/push via SSH
- Removed branch creation and PR creation steps in favor of direct push to main

## Test plan
- [ ] Verify the `CLAUDE_CODE_ACTION_REPO_DEPLOY_KEY` secret is properly configured in the release environment
- [ ] Test the workflow by creating a new release tag
- [ ] Confirm the action.yml in claude-code-action repo is updated directly on main

🤖 Generated with [Claude Code](https://claude.ai/code)