### PR TITLE
fix: filter version tags in release workflow to exclude non-version tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,11 @@ jobs:
       - name: Get latest tag
         id: get_latest_tag
         run: |
-          latest_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          # Get only version tags (v + number pattern)
+          latest_tag=$(git tag -l 'v[0-9]*' | sort -V | tail -1 || echo "v0.0.0")
+          if [ -z "$latest_tag" ]; then
+            latest_tag="v0.0.0"
+          fi
           echo "latest_tag=$latest_tag" >> $GITHUB_OUTPUT
           echo "Latest tag: $latest_tag"
 


### PR DESCRIPTION
Dry run failed in CI: https://github.com/anthropics/claude-code-base-action/actions/runs/15571017440/job/43846640231

```
🔍 DRY RUN MODE
Would create tag: vbeta.0.1
From commit: 4c629eb3c[8](https://github.com/anthropics/claude-code-base-action/actions/runs/15571017440/job/43846640231#step:5:9)4875676a1d67fc376c00340d9e9862
Previous tag: beta
```

- Only consider tags matching v[0-9]* pattern
- Use sort -V for proper version sorting
- Prevents picking up tags like "beta" as latest version

🤖 Generated with [Claude Code](https://claude.ai/code)