### PR TITLE
feat: update release workflows to manage beta tag as latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,4 +76,56 @@ jobs:
 
           gh release create "$next_version" \
             --title "$next_version" \
-            --generate-notes
+            --generate-notes \
+            --latest=false # We want to keep beta as the latest
+
+  update-beta-tag:
+    needs: create-release
+    if: ${{ !inputs.dry_run }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Update beta tag
+        run: |
+          # Get the latest version tag
+          VERSION=$(git tag -l 'v[0-9]*' | sort -V | tail -1)
+
+          # Update the beta tag to point to this release
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -fa beta -m "Update beta tag to ${VERSION}"
+          git push origin beta --force
+
+      - name: Update beta release to be latest
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Update beta release to be marked as latest
+          gh release edit beta --latest
+
+  trigger-downstream-update:
+    needs: create-release
+    if: ${{ !inputs.dry_run }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger downstream action update
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Get the latest version tag
+          VERSION=$(gh api repos/${{ github.repository }}/tags --jq '.[0].name' | grep '^v[0-9]' || echo "")
+
+          if [ -n "$VERSION" ]; then
+            echo "Triggering downstream update for version: $VERSION"
+            gh workflow run update-downstream-action.yml \
+              --repo ${{ github.repository }} \
+              -f tag="$VERSION"
+          else
+            echo "Could not determine version tag, skipping downstream update"
+          fi

--- a/.github/workflows/update-downstream-action.yml
+++ b/.github/workflows/update-downstream-action.yml
@@ -7,6 +7,12 @@ on:
   push:
     tags:
       - "v*.*.*" # Trigger on version tags like v1.2.3
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to update downstream action to (e.g., v1.2.3)"
+        required: true
+        type: string
 
 jobs:
   update-downstream:
@@ -23,8 +29,16 @@ jobs:
       - name: Get release information
         id: release_info
         run: |
-          # Get the tag name and SHA
-          TAG_NAME=${GITHUB_REF#refs/tags/}
+          # Get the tag name based on trigger type
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG_NAME="${{ inputs.tag }}"
+            # Checkout the specific tag
+            git fetch --tags
+            git checkout "refs/tags/${TAG_NAME}"
+          else
+            TAG_NAME=${GITHUB_REF#refs/tags/}
+          fi
+
           TAG_SHA=$(git rev-parse HEAD)
           echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
           echo "TAG_SHA=$TAG_SHA" >> $GITHUB_ENV

--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -22,3 +22,10 @@ jobs:
           git config user.email github-actions[bot]@users.noreply.github.com
           git tag -fa beta -m "Update beta tag to ${VERSION}"
           git push origin beta --force
+
+      - name: Update beta release to be latest
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Update beta release to be marked as latest
+          gh release edit beta --latest


### PR DESCRIPTION
- Create new releases with make_latest=false
- Update beta tag after each release to point to latest version
- Mark beta release as latest in both release and update-major-tag workflows
- Add workflow_dispatch to update-downstream-action workflow
- Trigger downstream update automatically after creating releases

This ensures the beta tag always represents the latest release for GitHub Actions usage.