### PR TITLE
feat: update release workflows to use repository dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      next_version: ${{ steps.next_version.outputs.next_version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -113,19 +115,24 @@ jobs:
     needs: create-release
     if: ${{ !inputs.dry_run }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Trigger downstream action update
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          # Get the latest version tag
-          VERSION=$(gh api repos/${{ github.repository }}/tags --jq '.[0].name' | grep '^v[0-9]' || echo "")
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const version = '${{ needs.create-release.outputs.next_version }}';
+            console.log(`Triggering downstream update for version: ${version}`);
 
-          if [ -n "$VERSION" ]; then
-            echo "Triggering downstream update for version: $VERSION"
-            gh workflow run update-downstream-action.yml \
-              --repo ${{ github.repository }} \
-              -f tag="$VERSION"
-          else
-            echo "Could not determine version tag, skipping downstream update"
-          fi
+            await github.rest.repos.createDispatchEvent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event_type: 'update-downstream-action',
+              client_payload: {
+                tag: version
+              }
+            });
+
+            console.log('Successfully triggered downstream update');

--- a/.github/workflows/update-downstream-action.yml
+++ b/.github/workflows/update-downstream-action.yml
@@ -13,6 +13,8 @@ on:
         description: "Tag to update downstream action to (e.g., v1.2.3)"
         required: true
         type: string
+  repository_dispatch:
+    types: [update-downstream-action]
 
 jobs:
   update-downstream:
@@ -32,6 +34,11 @@ jobs:
           # Get the tag name based on trigger type
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             TAG_NAME="${{ inputs.tag }}"
+            # Checkout the specific tag
+            git fetch --tags
+            git checkout "refs/tags/${TAG_NAME}"
+          elif [ "${{ github.event_name }}" = "repository_dispatch" ]; then
+            TAG_NAME="${{ github.event.client_payload.tag }}"
             # Checkout the specific tag
             git fetch --tags
             git checkout "refs/tags/${TAG_NAME}"


### PR DESCRIPTION
- Add repository_dispatch trigger to update-downstream-action.yml
- Keep workflow_dispatch for manual triggering
- Update release.yml to use repository dispatch instead of workflow dispatch
- Pass version tag directly from create-release job output
- Add contents:write permission for repository dispatch

🤖 Generated with [Claude Code](https://claude.ai/code)