### PR TITLE
fix: write Claude settings to XDG config path when available

### DIFF
--- a/.github/workflows/test-mcp-servers.yml
+++ b/.github/workflows/test-mcp-servers.yml
@@ -76,3 +76,95 @@ jobs:
           fi
 
           echo "✓ All MCP server checks passed!"
+
+  test-mcp-config-flag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: |
+          bun install
+          cd test/mcp-test
+          bun install
+
+      - name: Debug environment paths (--mcp-config test)
+        run: |
+          echo "=== Environment Variables (--mcp-config test) ==="
+          echo "HOME: $HOME"
+          echo "XDG_CONFIG_HOME: ${XDG_CONFIG_HOME:-not set}"
+          echo "CLAUDE_CONFIG_DIR: ${CLAUDE_CONFIG_DIR:-not set}"
+          echo ""
+          echo "=== Expected Config Paths ==="
+          echo "GitHub action writes to: $HOME/.claude/settings.json"
+          if [ -n "${XDG_CONFIG_HOME:-}" ]; then
+            echo "Claude might read from: $XDG_CONFIG_HOME/claude/settings.json"
+          else
+            echo "Claude should read from: $HOME/.claude/settings.json"
+          fi
+          echo ""
+          echo "=== Actual File System ==="
+          ls -la $HOME/.claude/ || echo "No $HOME/.claude directory"
+          if [ -n "${XDG_CONFIG_HOME:-}" ]; then
+            ls -la $XDG_CONFIG_HOME/ || echo "No $XDG_CONFIG_HOME directory"
+            ls -la $XDG_CONFIG_HOME/claude/ || echo "No $XDG_CONFIG_HOME/claude directory"
+          fi
+
+      - name: Run Claude Code with --mcp-config flag
+        uses: ./
+        id: claude-config-test
+        with:
+          prompt: "List all available tools"
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          mcp_config: '{"mcpServers":{"test-server":{"type":"stdio","command":"bun","args":["simple-mcp-server.ts"],"env":{}}}}'
+        env:
+          # Change to test directory so bun can find the MCP server script
+          CLAUDE_WORKING_DIR: ${{ github.workspace }}/test/mcp-test
+
+      - name: Check MCP server output with --mcp-config
+        run: |
+          echo "Checking Claude output for MCP servers with --mcp-config flag..."
+
+          # Parse the JSON output
+          OUTPUT_FILE="${RUNNER_TEMP}/claude-execution-output.json"
+
+          if [ ! -f "$OUTPUT_FILE" ]; then
+            echo "Error: Output file not found!"
+            exit 1
+          fi
+
+          echo "Output file contents:"
+          cat $OUTPUT_FILE
+
+          # Check if mcp_servers field exists in the init event
+          if jq -e '.[] | select(.type == "system" and .subtype == "init") | .mcp_servers' "$OUTPUT_FILE" > /dev/null; then
+            echo "✓ Found mcp_servers in output"
+            
+            # Check if test-server is connected
+            if jq -e '.[] | select(.type == "system" and .subtype == "init") | .mcp_servers[] | select(.name == "test-server" and .status == "connected")' "$OUTPUT_FILE" > /dev/null; then
+              echo "✓ test-server is connected"
+            else
+              echo "✗ test-server not found or not connected"
+              jq '.[] | select(.type == "system" and .subtype == "init") | .mcp_servers' "$OUTPUT_FILE"
+              exit 1
+            fi
+            
+            # Check if mcp tools are available
+            if jq -e '.[] | select(.type == "system" and .subtype == "init") | .tools[] | select(. == "mcp__test-server__test_tool")' "$OUTPUT_FILE" > /dev/null; then
+              echo "✓ MCP test tool found"
+            else
+              echo "✗ MCP test tool not found"
+              jq '.[] | select(.type == "system" and .subtype == "init") | .tools' "$OUTPUT_FILE"
+              exit 1
+            fi
+          else
+            echo "✗ No mcp_servers field found in init event"
+            jq '.[] | select(.type == "system" and .subtype == "init")' "$OUTPUT_FILE"
+            exit 1
+          fi
+
+          echo "✓ All MCP server checks passed with --mcp-config flag!"

--- a/src/setup-claude-code-settings.ts
+++ b/src/setup-claude-code-settings.ts
@@ -1,14 +1,29 @@
 import { $ } from "bun";
 import { homedir } from "os";
+import { join } from "path";
+
+/**
+ * Get Claude's config directory using XDG path when available
+ * Priority order:
+ * 1. XDG_CONFIG_HOME/claude (XDG Base Directory spec)
+ * 2. ~/.claude (legacy fallback)
+ */
+function getClaudeConfigHomeDir(): string {
+  if (process.env.XDG_CONFIG_HOME) {
+    return join(process.env.XDG_CONFIG_HOME, "claude");
+  }
+
+  return join(homedir(), ".claude");
+}
 
 export async function setupClaudeCodeSettings() {
-  const home = homedir();
-  const settingsPath = `${home}/.claude/settings.json`;
+  const configDir = getClaudeConfigHomeDir();
+  const settingsPath = join(configDir, "settings.json");
   console.log(`Setting up Claude settings at: ${settingsPath}`);
 
-  // Ensure .claude directory exists
-  console.log(`Creating .claude directory...`);
-  await $`mkdir -p ${home}/.claude`.quiet();
+  // Ensure config directory exists
+  console.log(`Creating config directory...`);
+  await $`mkdir -p ${configDir}`.quiet();
 
   let settings: Record<string, unknown> = {};
   try {


### PR DESCRIPTION
Updates setup-claude-code-settings.ts to use the same path resolution logic as Claude CLI when XDG_CONFIG_HOME is set. This fixes MCP server testing in CI environments where XDG_CONFIG_HOME is set but the action was writing to ~/.claude/settings.json while Claude CLI was reading from $XDG_CONFIG_HOME/claude/settings.json.

🤖 Generated with [Claude Code](https://claude.ai/code)