### PR TITLE
Revert XDG config path support while keeping test improvements

### DIFF
--- a/.github/workflows/test-mcp-servers.yml
+++ b/.github/workflows/test-mcp-servers.yml
@@ -96,23 +96,13 @@ jobs:
         run: |
           echo "=== Environment Variables (--mcp-config test) ==="
           echo "HOME: $HOME"
-          echo "XDG_CONFIG_HOME: ${XDG_CONFIG_HOME:-not set}"
-          echo "CLAUDE_CONFIG_DIR: ${CLAUDE_CONFIG_DIR:-not set}"
           echo ""
           echo "=== Expected Config Paths ==="
           echo "GitHub action writes to: $HOME/.claude/settings.json"
-          if [ -n "${XDG_CONFIG_HOME:-}" ]; then
-            echo "Claude might read from: $XDG_CONFIG_HOME/claude/settings.json"
-          else
-            echo "Claude should read from: $HOME/.claude/settings.json"
-          fi
+          echo "Claude should read from: $HOME/.claude/settings.json"
           echo ""
           echo "=== Actual File System ==="
           ls -la $HOME/.claude/ || echo "No $HOME/.claude directory"
-          if [ -n "${XDG_CONFIG_HOME:-}" ]; then
-            ls -la $XDG_CONFIG_HOME/ || echo "No $XDG_CONFIG_HOME directory"
-            ls -la $XDG_CONFIG_HOME/claude/ || echo "No $XDG_CONFIG_HOME/claude directory"
-          fi
 
       - name: Run Claude Code with --mcp-config flag
         uses: ./

--- a/src/setup-claude-code-settings.ts
+++ b/src/setup-claude-code-settings.ts
@@ -1,29 +1,14 @@
 import { $ } from "bun";
 import { homedir } from "os";
-import { join } from "path";
-
-/**
- * Get Claude's config directory using XDG path when available
- * Priority order:
- * 1. XDG_CONFIG_HOME/claude (XDG Base Directory spec)
- * 2. ~/.claude (legacy fallback)
- */
-function getClaudeConfigHomeDir(): string {
-  if (process.env.XDG_CONFIG_HOME) {
-    return join(process.env.XDG_CONFIG_HOME, "claude");
-  }
-
-  return join(homedir(), ".claude");
-}
 
 export async function setupClaudeCodeSettings() {
-  const configDir = getClaudeConfigHomeDir();
-  const settingsPath = join(configDir, "settings.json");
+  const home = homedir();
+  const settingsPath = `${home}/.claude/settings.json`;
   console.log(`Setting up Claude settings at: ${settingsPath}`);
 
-  // Ensure config directory exists
-  console.log(`Creating config directory...`);
-  await $`mkdir -p ${configDir}`.quiet();
+  // Ensure .claude directory exists
+  console.log(`Creating .claude directory...`);
+  await $`mkdir -p ${home}/.claude`.quiet();
 
   let settings: Record<string, unknown> = {};
   try {


### PR DESCRIPTION
## Summary
- Reverts the XDG config path changes that were causing issues
- Keeps the test improvements from the original PR

## Test plan

The changes revert to previous working behavior

🤖 Generated with [Claude Code](https://claude.ai/code)