### PR TITLE
feat: add fallback model support to Claude Code Base Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ Add the following to your workflow file:
       DEBUG: true
     allowed_tools: "Bash(git:*),View,GlobTool,GrepTool,BatchTool"
     anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+# Using fallback model for handling API errors
+- name: Run Claude Code with fallback model
+  uses: anthropics/claude-code-base-action@beta
+  with:
+    prompt: "Review and fix TypeScript errors"
+    model: "claude-opus-4-20250514"
+    fallback_model: "claude-sonnet-4-20250514"
+    allowed_tools: "Bash(git:*),View,GlobTool,GrepTool,BatchTool"
+    anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 ```
 
 ## Inputs
@@ -80,6 +90,7 @@ Add the following to your workflow file:
 | `claude_env`           | Custom environment variables to pass to Claude Code execution (YAML multiline format)             | No       | ''                           |
 | `model`                | Model to use (provider-specific format required for Bedrock/Vertex)                               | No       | 'claude-4-0-sonnet-20250219' |
 | `anthropic_model`      | DEPRECATED: Use 'model' instead                                                                   | No       | 'claude-4-0-sonnet-20250219' |
+| `fallback_model`       | Enable automatic fallback to specified model when default model is overloaded                     | No       | ''                           |
 | `timeout_minutes`      | Timeout in minutes for Claude Code execution                                                      | No       | '10'                         |
 | `anthropic_api_key`    | Anthropic API key (required for direct Anthropic API)                                             | No       | ''                           |
 | `use_bedrock`          | Use Amazon Bedrock with OIDC authentication instead of direct Anthropic API                       | No       | 'false'                      |

--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,9 @@ inputs:
   anthropic_model:
     description: "DEPRECATED: Use 'model' instead. Model to use (provider-specific format required for Bedrock/Vertex)"
     required: false
+  fallback_model:
+    description: "Enable automatic fallback to specified model when default model is unavailable"
+    required: false
   claude_env:
     description: "Custom environment variables to pass to Claude Code execution (YAML multiline format)"
     required: false
@@ -130,6 +133,7 @@ runs:
         INPUT_APPEND_SYSTEM_PROMPT: ${{ inputs.append_system_prompt }}
         INPUT_TIMEOUT_MINUTES: ${{ inputs.timeout_minutes }}
         INPUT_CLAUDE_ENV: ${{ inputs.claude_env }}
+        INPUT_FALLBACK_MODEL: ${{ inputs.fallback_model }}
 
         # Provider configuration
         ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ async function run() {
       systemPrompt: process.env.INPUT_SYSTEM_PROMPT,
       appendSystemPrompt: process.env.INPUT_APPEND_SYSTEM_PROMPT,
       claudeEnv: process.env.INPUT_CLAUDE_ENV,
+      fallbackModel: process.env.INPUT_FALLBACK_MODEL,
     });
   } catch (error) {
     core.setFailed(`Action failed with error: ${error}`);

--- a/src/run-claude.ts
+++ b/src/run-claude.ts
@@ -19,6 +19,7 @@ export type ClaudeOptions = {
   systemPrompt?: string;
   appendSystemPrompt?: string;
   claudeEnv?: string;
+  fallbackModel?: string;
 };
 
 type PreparedConfig = {
@@ -88,6 +89,9 @@ export function prepareRunConfig(
   }
   if (options.appendSystemPrompt) {
     claudeArgs.push("--append-system-prompt", options.appendSystemPrompt);
+  }
+  if (options.fallbackModel) {
+    claudeArgs.push("--fallback-model", options.fallbackModel);
   }
 
   // Parse custom environment variables

--- a/test/run-claude.test.ts
+++ b/test/run-claude.test.ts
@@ -86,6 +86,16 @@ describe("prepareRunConfig", () => {
     );
   });
 
+  test("should include fallback model in command arguments", () => {
+    const options: ClaudeOptions = {
+      fallbackModel: "claude-sonnet-4-20250514",
+    };
+    const prepared = prepareRunConfig("/tmp/test-prompt.txt", options);
+
+    expect(prepared.claudeArgs).toContain("--fallback-model");
+    expect(prepared.claudeArgs).toContain("claude-sonnet-4-20250514");
+  });
+
   test("should use provided prompt path", () => {
     const options: ClaudeOptions = {};
     const prepared = prepareRunConfig("/custom/prompt/path.txt", options);
@@ -103,6 +113,7 @@ describe("prepareRunConfig", () => {
     expect(prepared.claudeArgs).not.toContain("--mcp-config");
     expect(prepared.claudeArgs).not.toContain("--system-prompt");
     expect(prepared.claudeArgs).not.toContain("--append-system-prompt");
+    expect(prepared.claudeArgs).not.toContain("--fallback-model");
   });
 
   test("should preserve order of claude arguments", () => {
@@ -121,6 +132,40 @@ describe("prepareRunConfig", () => {
       "Bash,Read",
       "--max-turns",
       "3",
+    ]);
+  });
+
+  test("should preserve order with all options including fallback model", () => {
+    const options: ClaudeOptions = {
+      allowedTools: "Bash,Read",
+      disallowedTools: "Write",
+      maxTurns: "3",
+      mcpConfig: "/path/to/config.json",
+      systemPrompt: "You are a helpful assistant",
+      appendSystemPrompt: "Be concise",
+      fallbackModel: "claude-sonnet-4-20250514",
+    };
+    const prepared = prepareRunConfig("/tmp/test-prompt.txt", options);
+
+    expect(prepared.claudeArgs).toEqual([
+      "-p",
+      "--verbose",
+      "--output-format",
+      "stream-json",
+      "--allowedTools",
+      "Bash,Read",
+      "--disallowedTools",
+      "Write",
+      "--max-turns",
+      "3",
+      "--mcp-config",
+      "/path/to/config.json",
+      "--system-prompt",
+      "You are a helpful assistant",
+      "--append-system-prompt",
+      "Be concise",
+      "--fallback-model",
+      "claude-sonnet-4-20250514",
     ]);
   });
 


### PR DESCRIPTION
- Add fallback_model input to action.yml
- Pass fallback model through to Claude CLI with --fallback-model flag
- Add tests for fallback model functionality
- Document fallback model usage in README with example
- Useful for handling API overload scenarios in CI/CD environments