### PR TITLE
feat: add OAuth token authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,29 +73,38 @@ Add the following to your workflow file:
     fallback_model: "claude-sonnet-4-20250514"
     allowed_tools: "Bash(git:*),View,GlobTool,GrepTool,BatchTool"
     anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+# Using OAuth token instead of API key
+- name: Run Claude Code with OAuth token
+  uses: anthropics/claude-code-base-action@beta
+  with:
+    prompt: "Update dependencies"
+    allowed_tools: "Bash(git:*),View,GlobTool,GrepTool,BatchTool"
+    claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 ```
 
 ## Inputs
 
-| Input                  | Description                                                                                       | Required | Default                      |
-| ---------------------- | ------------------------------------------------------------------------------------------------- | -------- | ---------------------------- |
-| `prompt`               | The prompt to send to Claude Code                                                                 | No\*     | ''                           |
-| `prompt_file`          | Path to a file containing the prompt to send to Claude Code                                       | No\*     | ''                           |
-| `allowed_tools`        | Comma-separated list of allowed tools for Claude Code to use                                      | No       | ''                           |
-| `disallowed_tools`     | Comma-separated list of disallowed tools that Claude Code cannot use                              | No       | ''                           |
-| `max_turns`            | Maximum number of conversation turns (default: no limit)                                          | No       | ''                           |
-| `mcp_config`           | Path to the MCP configuration JSON file, or MCP configuration JSON string                         | No       | ''                           |
-| `system_prompt`        | Override system prompt                                                                            | No       | ''                           |
-| `append_system_prompt` | Append to system prompt                                                                           | No       | ''                           |
-| `claude_env`           | Custom environment variables to pass to Claude Code execution (YAML multiline format)             | No       | ''                           |
-| `model`                | Model to use (provider-specific format required for Bedrock/Vertex)                               | No       | 'claude-4-0-sonnet-20250219' |
-| `anthropic_model`      | DEPRECATED: Use 'model' instead                                                                   | No       | 'claude-4-0-sonnet-20250219' |
-| `fallback_model`       | Enable automatic fallback to specified model when default model is overloaded                     | No       | ''                           |
-| `timeout_minutes`      | Timeout in minutes for Claude Code execution                                                      | No       | '10'                         |
-| `anthropic_api_key`    | Anthropic API key (required for direct Anthropic API)                                             | No       | ''                           |
-| `use_bedrock`          | Use Amazon Bedrock with OIDC authentication instead of direct Anthropic API                       | No       | 'false'                      |
-| `use_vertex`           | Use Google Vertex AI with OIDC authentication instead of direct Anthropic API                     | No       | 'false'                      |
-| `use_node_cache`       | Whether to use Node.js dependency caching (set to true only for Node.js projects with lock files) | No       | 'false'                      |
+| Input                     | Description                                                                                       | Required | Default                      |
+| ------------------------- | ------------------------------------------------------------------------------------------------- | -------- | ---------------------------- |
+| `prompt`                  | The prompt to send to Claude Code                                                                 | No\*     | ''                           |
+| `prompt_file`             | Path to a file containing the prompt to send to Claude Code                                       | No\*     | ''                           |
+| `allowed_tools`           | Comma-separated list of allowed tools for Claude Code to use                                      | No       | ''                           |
+| `disallowed_tools`        | Comma-separated list of disallowed tools that Claude Code cannot use                              | No       | ''                           |
+| `max_turns`               | Maximum number of conversation turns (default: no limit)                                          | No       | ''                           |
+| `mcp_config`              | Path to the MCP configuration JSON file, or MCP configuration JSON string                         | No       | ''                           |
+| `system_prompt`           | Override system prompt                                                                            | No       | ''                           |
+| `append_system_prompt`    | Append to system prompt                                                                           | No       | ''                           |
+| `claude_env`              | Custom environment variables to pass to Claude Code execution (YAML multiline format)             | No       | ''                           |
+| `model`                   | Model to use (provider-specific format required for Bedrock/Vertex)                               | No       | 'claude-4-0-sonnet-20250219' |
+| `anthropic_model`         | DEPRECATED: Use 'model' instead                                                                   | No       | 'claude-4-0-sonnet-20250219' |
+| `fallback_model`          | Enable automatic fallback to specified model when default model is overloaded                     | No       | ''                           |
+| `timeout_minutes`         | Timeout in minutes for Claude Code execution                                                      | No       | '10'                         |
+| `anthropic_api_key`       | Anthropic API key (required for direct Anthropic API)                                             | No       | ''                           |
+| `claude_code_oauth_token` | Claude Code OAuth token (alternative to anthropic_api_key)                                        | No       | ''                           |
+| `use_bedrock`             | Use Amazon Bedrock with OIDC authentication instead of direct Anthropic API                       | No       | 'false'                      |
+| `use_vertex`              | Use Google Vertex AI with OIDC authentication instead of direct Anthropic API                     | No       | 'false'                      |
+| `use_node_cache`          | Whether to use Node.js dependency caching (set to true only for Node.js projects with lock files) | No       | 'false'                      |
 
 \*Either `prompt` or `prompt_file` must be provided, but not both.
 
@@ -313,9 +322,9 @@ Check out additional examples in [`./examples`](./examples).
 
 ## Using Cloud Providers
 
-You can authenticate with Claude using any of these three methods:
+You can authenticate with Claude using any of these methods:
 
-1. Direct Anthropic API (default) - requires API key
+1. Direct Anthropic API (default) - requires API key or OAuth token
 2. Amazon Bedrock - requires OIDC authentication and automatically uses cross-region inference profiles
 3. Google Vertex AI - requires OIDC authentication
 

--- a/action.yml
+++ b/action.yml
@@ -63,6 +63,10 @@ inputs:
     description: "Anthropic API key (required for direct Anthropic API)"
     required: false
     default: ""
+  claude_code_oauth_token:
+    description: "Claude Code OAuth token (alternative to anthropic_api_key)"
+    required: false
+    default: ""
   use_bedrock:
     description: "Use Amazon Bedrock with OIDC authentication instead of direct Anthropic API"
     required: false
@@ -137,6 +141,7 @@ runs:
 
         # Provider configuration
         ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
+        CLAUDE_CODE_OAUTH_TOKEN: ${{ inputs.claude_code_oauth_token }}
         ANTHROPIC_BASE_URL: ${{ env.ANTHROPIC_BASE_URL }}
         # Only set provider flags if explicitly true, since any value (including "false") is truthy
         CLAUDE_CODE_USE_BEDROCK: ${{ inputs.use_bedrock == 'true' && '1' || '' }}

--- a/src/validate-env.ts
+++ b/src/validate-env.ts
@@ -6,6 +6,7 @@ export function validateEnvironmentVariables() {
   const useBedrock = process.env.CLAUDE_CODE_USE_BEDROCK === "1";
   const useVertex = process.env.CLAUDE_CODE_USE_VERTEX === "1";
   const anthropicApiKey = process.env.ANTHROPIC_API_KEY;
+  const claudeCodeOAuthToken = process.env.CLAUDE_CODE_OAUTH_TOKEN;
 
   const errors: string[] = [];
 
@@ -16,9 +17,9 @@ export function validateEnvironmentVariables() {
   }
 
   if (!useBedrock && !useVertex) {
-    if (!anthropicApiKey) {
+    if (!anthropicApiKey && !claudeCodeOAuthToken) {
       errors.push(
-        "ANTHROPIC_API_KEY is required when using direct Anthropic API.",
+        "Either ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is required when using direct Anthropic API.",
       );
     }
   } else if (useBedrock) {

--- a/test/validate-env.test.ts
+++ b/test/validate-env.test.ts
@@ -38,7 +38,7 @@ describe("validateEnvironmentVariables", () => {
 
     test("should fail when ANTHROPIC_API_KEY is missing", () => {
       expect(() => validateEnvironmentVariables()).toThrow(
-        "ANTHROPIC_API_KEY is required when using direct Anthropic API.",
+        "Either ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is required when using direct Anthropic API.",
       );
     });
   });


### PR DESCRIPTION
Add claude_code_oauth_token as an alternative authentication method to anthropic_api_key. The OAuth token is passed as CLAUDE_CODE_OAUTH_TOKEN environment variable.

- Add claude_code_oauth_token input to action.yml
- Update validation to accept either API key or OAuth token
- Document OAuth token usage in README with example
- Update authentication methods documentation

🤖 Generated with [Claude Code](https://claude.ai/code)