### PR TITLE
Security : Pin actions versions with hash, avoid script injections

### DIFF
--- a/.github/workflows/bump-claude-code-version.yml
+++ b/.github/workflows/bump-claude-code-version.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4
         with:
           token: ${{ secrets.RELEASE_PAT }}
           fetch-depth: 0
@@ -31,10 +31,13 @@ jobs:
         run: |
           # Get version from either repository_dispatch or workflow_dispatch
           if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
-            NEW_VERSION="${{ github.event.client_payload.version }}"
+            NEW_VERSION="${CLIENT_PAYLOAD_VERSION}"
           else
-            NEW_VERSION="${{ inputs.version }}"
+            NEW_VERSION="${INPUT_VERSION}"
           fi
+
+          # Sanitize the version to avoid issues enabled by problematic characters
+          NEW_VERSION=$(echo "$NEW_VERSION" | tr -d '`;$(){}[]|&<>' | tr -s ' ' '-')
 
           if [ -z "$NEW_VERSION" ]; then
             echo "Error: version not provided"
@@ -42,6 +45,9 @@ jobs:
           fi
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
           echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          CLIENT_PAYLOAD_VERSION: ${{ github.event.client_payload.version }}
 
       - name: Create branch and update action.yml
         run: |
@@ -52,21 +58,21 @@ jobs:
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
 
           # Get the default branch
-          DEFAULT_BRANCH=$(gh api repos/${{ github.repository }} --jq '.default_branch')
+          DEFAULT_BRANCH=$(gh api repos/${GITHUB_REPOSITORY} --jq '.default_branch')
           echo "DEFAULT_BRANCH=$DEFAULT_BRANCH" >> $GITHUB_ENV
 
           # Get the latest commit SHA from the default branch
-          BASE_SHA=$(gh api repos/${{ github.repository }}/git/refs/heads/$DEFAULT_BRANCH --jq '.object.sha')
+          BASE_SHA=$(gh api repos/${GITHUB_REPOSITORY}/git/refs/heads/$DEFAULT_BRANCH --jq '.object.sha')
 
           # Create a new branch
           gh api \
             --method POST \
-            repos/${{ github.repository }}/git/refs \
+            repos/${GITHUB_REPOSITORY}/git/refs \
             -f ref="refs/heads/$BRANCH_NAME" \
             -f sha="$BASE_SHA"
 
           # Get the current action.yml content
-          ACTION_CONTENT=$(gh api repos/${{ github.repository }}/contents/action.yml?ref=$DEFAULT_BRANCH --jq '.content' | base64 -d)
+          ACTION_CONTENT=$(gh api repos/${GITHUB_REPOSITORY}/contents/action.yml?ref=$DEFAULT_BRANCH --jq '.content' | base64 -d)
 
           # Update the Claude Code version in the npm install command
           UPDATED_CONTENT=$(echo "$ACTION_CONTENT" | sed -E "s/(npm install -g @anthropic-ai\/claude-code@)[0-9]+\.[0-9]+\.[0-9]+/\1${{ env.NEW_VERSION }}/")
@@ -78,7 +84,7 @@ jobs:
           fi
 
           # Get the current SHA of action.yml for the update API call
-          FILE_SHA=$(gh api repos/${{ github.repository }}/contents/action.yml?ref=$DEFAULT_BRANCH --jq '.sha')
+          FILE_SHA=$(gh api repos/${GITHUB_REPOSITORY}/contents/action.yml?ref=$DEFAULT_BRANCH --jq '.sha')
 
           # Create the updated action.yml content in base64
           echo "$UPDATED_CONTENT" | base64 > action.yml.b64
@@ -86,7 +92,7 @@ jobs:
           # Commit the updated action.yml via GitHub API
           gh api \
             --method PUT \
-            repos/${{ github.repository }}/contents/action.yml \
+            repos/${GITHUB_REPOSITORY}/contents/action.yml \
             -f message="chore: bump Claude Code version to ${{ env.NEW_VERSION }}" \
             -F content=@action.yml.b64 \
             -f sha="$FILE_SHA" \
@@ -95,6 +101,7 @@ jobs:
           echo "Successfully created branch and updated Claude Code version to ${{ env.NEW_VERSION }}"
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
 
       - name: Create Pull Request
         run: |
@@ -102,7 +109,7 @@ jobs:
           if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
             TRIGGER_INFO="repository dispatch event"
           else
-            TRIGGER_INFO="manual workflow dispatch by @${{ github.actor }}"
+            TRIGGER_INFO="manual workflow dispatch by @${GITHUB_ACTOR}"
           fi
 
           # Create PR body with proper YAML escape
@@ -110,12 +117,16 @@ jobs:
 
           echo "Creating PR with gh pr create command"
           PR_URL=$(gh pr create \
-            --repo "${{ github.repository }}" \
+            --repo "${GITHUB_REPOSITORY}" \
             --title "chore: bump Claude Code version to ${{ env.NEW_VERSION }}" \
             --body "$PR_BODY" \
-            --base "${{ env.DEFAULT_BRANCH }}" \
-            --head "${{ env.BRANCH_NAME }}")
+            --base "${DEFAULT_BRANCH}" \
+            --head "${BRANCH_NAME}")
 
           echo "PR created successfully: $PR_URL"
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_ACTOR: ${{ github.actor }}
+          DEFAULT_BRANCH: ${{ env.DEFAULT_BRANCH }}
+          BRANCH_NAME: ${{ env.BRANCH_NAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ jobs:
   prettier:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-      - uses: oven-sh/setup-bun@v1
+      - uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1
         with:
           bun-version: 1.2.12
 
@@ -24,9 +24,9 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-      - uses: oven-sh/setup-bun@v1
+      - uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1
         with:
           bun-version: 1.2.12
 
@@ -39,9 +39,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-      - uses: oven-sh/setup-bun@v1
+      - uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1
         with:
           bun-version: 1.2.12
 

--- a/.github/workflows/claude-pr.yml
+++ b/.github/workflows/claude-pr.yml
@@ -25,7 +25,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4
         with:
           fetch-depth: 1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,7 @@ jobs:
       contents: write
     steps:
       - name: Trigger downstream action update
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -16,7 +16,7 @@ jobs:
   test-inline-prompt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Test with inline prompt
         id: inline-test
@@ -66,13 +66,15 @@ jobs:
   test-prompt-file:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Create test prompt file
         run: |
           cat > test-prompt.txt << EOF
-          ${{ github.event.inputs.test_prompt || 'List the files in the current directory starting with "package"' }}
+          ${PROMPT}
           EOF
+        env:
+          PROMPT: ${{ github.event.inputs.test_prompt || 'List the files in the current directory starting with "package"' }}
 
       - name: Test with prompt file and allowed tools
         id: prompt-file-test

--- a/.github/workflows/test-claude-env.yml
+++ b/.github/workflows/test-claude-env.yml
@@ -11,7 +11,7 @@ jobs:
   test-claude-env-with-comments:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Test with comments in env
         id: comment-test

--- a/.github/workflows/test-mcp-servers.yml
+++ b/.github/workflows/test-mcp-servers.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 #v2
 
       - name: Install dependencies
         run: |
@@ -81,10 +81,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 #v2
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/update-downstream-action.yml
+++ b/.github/workflows/update-downstream-action.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout current repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
 
@@ -33,12 +33,12 @@ jobs:
         run: |
           # Get the tag name based on trigger type
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG_NAME="${{ inputs.tag }}"
+            TAG_NAME="${INPUT_TAG}"
             # Checkout the specific tag
             git fetch --tags
             git checkout "refs/tags/${TAG_NAME}"
           elif [ "${{ github.event_name }}" = "repository_dispatch" ]; then
-            TAG_NAME="${{ github.event.client_payload.tag }}"
+            TAG_NAME="${CLIENT_PAYLOAD_TAG}"
             # Checkout the specific tag
             git fetch --tags
             git checkout "refs/tags/${TAG_NAME}"
@@ -51,6 +51,9 @@ jobs:
           echo "TAG_SHA=$TAG_SHA" >> $GITHUB_ENV
           echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
           echo "tag_sha=$TAG_SHA" >> $GITHUB_OUTPUT
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+          CLIENT_PAYLOAD_TAG: ${{ github.event.client_payload.tag }}
 
       - name: Clone claude-code-action repository
         run: |

--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -10,7 +10,9 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 0
 
       - name: Update beta tag
         run: |

--- a/examples/issue-triage.yml
+++ b/examples/issue-triage.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
 
@@ -51,7 +51,7 @@ jobs:
           IMPORTANT: Don't post any comments or messages to the issue. Your only action should be to apply labels.
 
           Issue Information:
-          - REPO: ${{ github.repository }}
+          - REPO: ${GITHUB_REPOSITORY}
           - ISSUE_NUMBER: ${{ github.event.issue.number }}
 
           TASK OVERVIEW:
@@ -95,6 +95,8 @@ jobs:
           - Your ONLY action should be to apply labels using mcp__github__update_issue
           - It's okay to not add any labels if none are clearly applicable
           EOF
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
 
       - name: Run Claude Code for Issue Triage
         uses: anthropics/claude-code-base-action@beta


### PR DESCRIPTION
- Pin versions of GitHub actions with the hash. I used the format with `@<hash> # vX` because this format is recognized by Dependabot. I don't know about other tools like Renovate

- Sanitized some data. It is (strongly) recommended to avoid using the templating syntax in a `run:` block unless you are very sure it can not be directly or indirectly controlled by a user.