### PR TITLE
test: isolate settings tests to use temporary directories

### DIFF
--- a/src/setup-claude-code-settings.ts
+++ b/src/setup-claude-code-settings.ts
@@ -2,8 +2,11 @@ import { $ } from "bun";
 import { homedir } from "os";
 import { readFile } from "fs/promises";
 
-export async function setupClaudeCodeSettings(settingsInput?: string) {
-  const home = homedir();
+export async function setupClaudeCodeSettings(
+  settingsInput?: string,
+  homeDir?: string,
+) {
+  const home = homeDir ?? homedir();
   const settingsPath = `${home}/.claude/settings.json`;
   console.log(`Setting up Claude settings at: ${settingsPath}`);
 


### PR DESCRIPTION
Modified the setup-claude-code-settings tests to use temporary directories instead of modifying the actual ~/.claude/settings.json file. This prevents test runs from affecting the user's real Claude Code settings.

Changes:
- Added optional homeDir parameter to setupClaudeCodeSettings function
- Updated all tests to use a temporary directory in tmpdir()
- Tests now create isolated environments that are cleaned up after each test

🤖 Generated with [Claude Code](https://claude.ai/code)