### PR TITLE
Add show_full_output option to control output verbosity

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository is an automated mirror of the `base-action` directory from [anth
 - 📖 [View documentation](https://github.com/anthropics/claude-code-action#readme)
 
 ---
+
 # Claude Code Base Action
 
 This GitHub Action allows you to run [Claude Code](https://www.anthropic.com/claude-code) within your GitHub Actions workflows. You can use this to build any custom workflow on top of Claude Code.
@@ -116,8 +117,11 @@ Add the following to your workflow file:
 | `use_bedrock`             | Use Amazon Bedrock with OIDC authentication instead of direct Anthropic API                       | No       | 'false'                      |
 | `use_vertex`              | Use Google Vertex AI with OIDC authentication instead of direct Anthropic API                     | No       | 'false'                      |
 | `use_node_cache`          | Whether to use Node.js dependency caching (set to true only for Node.js projects with lock files) | No       | 'false'                      |
+| `show_full_output`        | Show full JSON output (⚠️ WARNING: May expose secrets in logs - see Security section)             | No       | 'false'\*                    |
 
 \*Either `prompt` or `prompt_file` must be provided, but not both.
+
+\*\*Note: `show_full_output` is automatically enabled when GitHub Actions debug mode is active (when the `ACTIONS_STEP_DEBUG` secret is set to `true`).
 
 ## Outputs
 
@@ -495,6 +499,8 @@ This example shows how to use OIDC authentication with GCP Vertex AI:
 
 **⚠️ IMPORTANT: Never commit API keys directly to your repository! Always use GitHub Actions secrets.**
 
+### API Key Security
+
 To securely use your Anthropic API key:
 
 1. Add your API key as a repository secret:
@@ -526,6 +532,21 @@ anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
 This applies to all sensitive values including API keys, access tokens, and credentials.
 We also recommend that you always use short-lived tokens when possible
+
+### Full Output Security Warning
+
+The `show_full_output` option is **disabled by default** for security reasons. When enabled, it outputs ALL Claude Code messages including:
+
+- Full outputs from tool executions (e.g., `ps`, `env`, file reads)
+- API responses that may contain tokens or credentials
+- File contents that may include secrets
+- Command outputs that may expose sensitive system information
+
+**These logs are publicly visible in GitHub Actions for public repositories!**
+
+#### Automatic Enabling in Debug Mode
+
+Full output is **automatically enabled** when GitHub Actions debug mode is active (when `ACTIONS_STEP_DEBUG` secret is set to `true`). This helps with debugging but carries the same security risks.
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,10 @@ inputs:
     description: "Optional path to a custom Bun executable. If provided, skips automatic Bun installation and uses this executable instead. WARNING: Using an incompatible version may cause problems if the action requires specific Bun features. This input is typically not needed unless you're debugging something specific or have unique needs in your environment."
     required: false
     default: ""
+  show_full_output:
+    description: "Show full JSON output from Claude Code. WARNING: This outputs ALL Claude messages including tool execution results which may contain secrets, API keys, or other sensitive information. These logs are publicly visible in GitHub Actions. Only enable for debugging in non-sensitive environments."
+    required: false
+    default: "false"
 
 outputs:
   conclusion:
@@ -126,6 +130,7 @@ runs:
         INPUT_CLAUDE_ARGS: ${{ inputs.claude_args }}
         INPUT_PATH_TO_CLAUDE_CODE_EXECUTABLE: ${{ inputs.path_to_claude_code_executable }}
         INPUT_PATH_TO_BUN_EXECUTABLE: ${{ inputs.path_to_bun_executable }}
+        INPUT_SHOW_FULL_OUTPUT: ${{ inputs.show_full_output }}
 
         # Provider configuration
         ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ async function run() {
       model: process.env.ANTHROPIC_MODEL,
       pathToClaudeCodeExecutable:
         process.env.INPUT_PATH_TO_CLAUDE_CODE_EXECUTABLE,
+      showFullOutput: process.env.INPUT_SHOW_FULL_OUTPUT,
     });
   } catch (error) {
     core.setFailed(`Action failed with error: ${error}`);

--- a/src/run-claude.ts
+++ b/src/run-claude.ts
@@ -12,6 +12,59 @@ const PIPE_PATH = `${process.env.RUNNER_TEMP}/claude_prompt_pipe`;
 const EXECUTION_FILE = `${process.env.RUNNER_TEMP}/claude-execution-output.json`;
 const BASE_ARGS = ["--verbose", "--output-format", "stream-json"];
 
+/**
+ * Sanitizes JSON output to remove sensitive information when full output is disabled
+ * Returns a safe summary message or null if the message should be completely suppressed
+ */
+function sanitizeJsonOutput(
+  jsonObj: any,
+  showFullOutput: boolean,
+): string | null {
+  if (showFullOutput) {
+    // In full output mode, return the full JSON
+    return JSON.stringify(jsonObj, null, 2);
+  }
+
+  // In non-full-output mode, provide minimal safe output
+  const type = jsonObj.type;
+  const subtype = jsonObj.subtype;
+
+  // System initialization - safe to show
+  if (type === "system" && subtype === "init") {
+    return JSON.stringify(
+      {
+        type: "system",
+        subtype: "init",
+        message: "Claude Code initialized",
+        model: jsonObj.model || "unknown",
+      },
+      null,
+      2,
+    );
+  }
+
+  // Result messages - Always show the final result
+  if (type === "result") {
+    // These messages contain the final result and should always be visible
+    return JSON.stringify(
+      {
+        type: "result",
+        subtype: jsonObj.subtype,
+        is_error: jsonObj.is_error,
+        duration_ms: jsonObj.duration_ms,
+        num_turns: jsonObj.num_turns,
+        total_cost_usd: jsonObj.total_cost_usd,
+        permission_denials: jsonObj.permission_denials,
+      },
+      null,
+      2,
+    );
+  }
+
+  // For any other message types, suppress completely in non-full-output mode
+  return null;
+}
+
 export type ClaudeOptions = {
   claudeArgs?: string;
   model?: string;
@@ -24,6 +77,7 @@ export type ClaudeOptions = {
   appendSystemPrompt?: string;
   claudeEnv?: string;
   fallbackModel?: string;
+  showFullOutput?: string;
 };
 
 type PreparedConfig = {
@@ -138,12 +192,24 @@ export async function runClaude(promptPath: string, options: ClaudeOptions) {
     pipeStream.destroy();
   });
 
+  // Determine if full output should be shown
+  // Show full output if explicitly set to "true" OR if GitHub Actions debug mode is enabled
+  const isDebugMode = process.env.ACTIONS_STEP_DEBUG === "true";
+  let showFullOutput = options.showFullOutput === "true" || isDebugMode;
+
+  if (isDebugMode && options.showFullOutput !== "false") {
+    console.log("Debug mode detected - showing full output");
+    showFullOutput = true;
+  } else if (!showFullOutput) {
+    console.log("Running Claude Code (full output hidden for security)...");
+  }
+
   // Capture output for parsing execution metrics
   let output = "";
   claudeProcess.stdout.on("data", (data) => {
     const text = data.toString();
 
-    // Try to parse as JSON and pretty print if it's on a single line
+    // Try to parse as JSON and handle based on verbose setting
     const lines = text.split("\n");
     lines.forEach((line: string, index: number) => {
       if (line.trim() === "") return;
@@ -151,17 +217,24 @@ export async function runClaude(promptPath: string, options: ClaudeOptions) {
       try {
         // Check if this line is a JSON object
         const parsed = JSON.parse(line);
-        const prettyJson = JSON.stringify(parsed, null, 2);
-        process.stdout.write(prettyJson);
-        if (index < lines.length - 1 || text.endsWith("\n")) {
-          process.stdout.write("\n");
+        const sanitizedOutput = sanitizeJsonOutput(parsed, showFullOutput);
+
+        if (sanitizedOutput) {
+          process.stdout.write(sanitizedOutput);
+          if (index < lines.length - 1 || text.endsWith("\n")) {
+            process.stdout.write("\n");
+          }
         }
       } catch (e) {
-        // Not a JSON object, print as is
-        process.stdout.write(line);
-        if (index < lines.length - 1 || text.endsWith("\n")) {
-          process.stdout.write("\n");
+        // Not a JSON object
+        if (showFullOutput) {
+          // In full output mode, print as is
+          process.stdout.write(line);
+          if (index < lines.length - 1 || text.endsWith("\n")) {
+            process.stdout.write("\n");
+          }
         }
+        // In non-full-output mode, suppress non-JSON output
       }
     });
 


### PR DESCRIPTION
## Summary
- Adds a new `show_full_output` input option (defaults to `false`) to control output verbosity
- When disabled, shows only essential information like errors, completion status, and tool names
- Automatically enables full output when GitHub Actions debug mode is active

## Changes
- Added `show_full_output` input to action.yml
- Implemented output sanitization in run-claude.ts to filter non-essential details when disabled
- Always shows permission denials, errors, and final result messages regardless of setting
- Updated documentation to explain the new option and its behavior with debug mode

## Why
This change reduces log noise in GitHub Actions by default, making it easier to see important information. Full output can still be enabled for debugging when needed.

## Test plan
- [ ] Test with `show_full_output: false` (default) - verify minimal output
- [ ] Test with `show_full_output: true` - verify full JSON output
- [ ] Test with `ACTIONS_STEP_DEBUG=true` - verify debug mode enables full output
- [ ] Verify permission denials and errors are always visible
- [ ] Verify final result message is always shown