### PR TITLE
docs(readme): bump example models to current versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ Add the following to your workflow file:
   uses: anthropics/claude-code-base-action@beta
   with:
     prompt: "Review and fix TypeScript errors"
-    model: "claude-opus-4-1-20250805"
-    fallback_model: "claude-sonnet-4-20250514"
+    model: "claude-opus-4-7"
+    fallback_model: "claude-sonnet-4-5-20250929"
     allowed_tools: "Bash(git:*),View,GlobTool,GrepTool,BatchTool"
     anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
@@ -238,7 +238,7 @@ Provide the settings configuration directly as a JSON string:
     prompt: "Your prompt here"
     settings: |
       {
-        "model": "claude-opus-4-1-20250805",
+        "model": "claude-opus-4-7",
         "env": {
           "DEBUG": "true",
           "API_URL": "https://api.example.com"


### PR DESCRIPTION
fixes #85.

the readme examples still reference claude-opus-4-1-20250805 and claude-sonnet-4-20250514. bumping the primary example to claude-opus-4-7 and the fallback example to claude-sonnet-4-5-20250929.

skipped the bedrock and vertex 3-7-sonnet examples in the provider sections since those provider-specific tags may be intentional. happy to bump those too if a maintainer confirms they should track current versions.